### PR TITLE
Fix error when pressing enter without input

### DIFF
--- a/denops/fuzzy-motion/main.ts
+++ b/denops/fuzzy-motion/main.ts
@@ -371,6 +371,9 @@ export const main = async (denops: Denops): Promise<void> => {
             | number
             | null;
           if (code === ENTER) {
+            if (targets.length === 0) {
+              return;
+            }
             code = targets[0].char.charCodeAt(0);
           }
 


### PR DESCRIPTION
SSIA

起動後、何も入力せずに Enter を押すと unhandled error が出るのを修正します。
